### PR TITLE
Corrected errors, slight revisions to lab 3 and cleanup

### DIFF
--- a/amazon-ecs-mythicalmysfits-workshop/Kubernetes/mono/monolith-app.yaml
+++ b/amazon-ecs-mythicalmysfits-workshop/Kubernetes/mono/monolith-app.yaml
@@ -23,7 +23,7 @@ spec:
               protocol: TCP
           env:
             - name: DDB_TABLE_NAME
-              value: Table-mythical-mysfits-core
+              value: Table-mythical-mysfits-eks
             - name: AWS_DEFAULT_REGION
               value: us-west-2
 ---

--- a/amazon-ecs-mythicalmysfits-workshop/workshop-1/Lab2.adoc
+++ b/amazon-ecs-mythicalmysfits-workshop/workshop-1/Lab2.adoc
@@ -208,7 +208,7 @@ aws s3 ls
 ```
 Note the bucket name where your index.html file is and copy your new index.html granting read permissions to everyone and full access to you (give your account email)
 ```
-aws s3 cp index.html s3://mythical-mysfits-core-mythicalbucket-xxx/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=emailaddress=user@example.com
+aws s3 cp index.html s3://-mythicalbucket-xxx/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers full=emailaddress=user@example.com
 ```
 
 image::images/S3Permissions.png[S3 permissions]
@@ -217,7 +217,7 @@ Note: Your bucket name will be different. If the email address doesn't work, go 
 
 17. now go and see your S3 website, it would have the URL format like: http://BUCKET_NAME.s3-website.us-west-2.amazonaws.com/
 
-For e.g. http://mythical-mysfits-core-mythicalbucket-6b9pvvt40bqj.s3-website.us-west-2.amazonaws.com/
+For e.g. http://mythical-mysfits-eks-mythicalbucket-6b9pvvt40bqj.s3-website.us-west-2.amazonaws.com/
 
 if you see all the mythical mysfits show up now, SUCCESS!! First hurdle done
 

--- a/amazon-ecs-mythicalmysfits-workshop/workshop-1/Lab3.md
+++ b/amazon-ecs-mythicalmysfits-workshop/workshop-1/Lab3.md
@@ -58,13 +58,9 @@ As with the monolith, you'll be using [EKS](https://aws.amazon.com/eks/) to depl
     $ docker push <b><i>ECR_REPOSITORY_URI</i></b>:like
     </pre>
 
-4. Navigate to Kubernetes/micro folder `/containers-sydsummit-eks-workshop-2019/amazon-ecs-mythicalmysfits-workshop/Kubernetes`. 
+4. Navigate to Kubernetes/micro folder `/containers-sydsummit-eks-workshop-2019/amazon-ecs-mythicalmysfits-workshop/Kubernetes`.  Open the `nolikeservice-app.yaml` file.  Repeat steps 1-4 from [*Lab 2*](Lab2.adoc).
 
-Now, just as in Lab 2, create a new revision of the kubernetes object (this time pointing to the "nolike" version of the container image), AND update the monolith service to use this revision. 
-
-Call this object nolike-app.yaml (there should be a sample file in the folder)
-
-**Note: If you are using the nolike-app.yaml file, remember to update the image file ECR URI and update DDB Table name in the sample file provided.**
+5. Replace the image ENV variable in the `nolikeservice-app.yaml` with the ECR ARN for the "nolike" version of the container image. Then, replace the `DDB_TABLE_NAME` value with your DynamoDB table name.  Update the monolith service to use this revision.
 
 5. Before we deploy this microservice, we'll go into the details of setting up the [ALB Ingress Controller](https://aws.amazon.com/blogs/opensource/kubernetes-ingress-aws-alb-ingress-controller/). 
 
@@ -116,7 +112,7 @@ You may see some errors show up about "target not found". That's because we have
 
 (Example: 07f66c03-default-mythicalm-761d-1712518784.us-west-2.elb.amazonaws.com) and modify the index.html file and upload to s3 again
 ```
-aws s3 cp ../../workshop-1/web/index.html s3://mythical-mysfits-core-mythicalbucket-xxx/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+aws s3 cp ../../workshop-1/web/index.html s3://mythical-mysfits-eks-mythicalbucket-xxx/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
 ```
 ALB can take 5-10 mins to be in-service
 

--- a/amazon-ecs-mythicalmysfits-workshop/workshop-1/Lab3.md
+++ b/amazon-ecs-mythicalmysfits-workshop/workshop-1/Lab3.md
@@ -62,7 +62,7 @@ As with the monolith, you'll be using [EKS](https://aws.amazon.com/eks/) to depl
 
 5. Replace the image ENV variable in the `nolikeservice-app.yaml` with the ECR ARN for the "nolike" version of the container image. Then, replace the `DDB_TABLE_NAME` value with your DynamoDB table name.  Update the monolith service to use this revision.
 
-5. Before we deploy this microservice, we'll go into the details of setting up the [ALB Ingress Controller](https://aws.amazon.com/blogs/opensource/kubernetes-ingress-aws-alb-ingress-controller/). 
+6. Before we deploy this microservice, we'll go into the details of setting up the [ALB Ingress Controller](https://aws.amazon.com/blogs/opensource/kubernetes-ingress-aws-alb-ingress-controller/). 
 
 >Kubernetes Ingress is an api object that allows you manage external (or) internal HTTP[s] access to Kubernetes services running in a cluster. Amazon Elastic Load Balancing Application Load Balancer (ALB) is a popular AWS service that load balances incoming traffic at the application layer (layer 7) across multiple targets, such as Amazon EC2 instances, in a region. ALB supports multiple features including host or path based routing, TLS (Transport layer security) termination, WebSockets, HTTP/2, AWS WAF (web application firewall) integration, integrated access logs, and health checks.
 
@@ -98,64 +98,65 @@ As with the monolith, you'll be using [EKS](https://aws.amazon.com/eks/) to depl
             -------------------------------------------------------------------------------
         ```
 
-6. Still at this point, you'd notice on the console that the ALB has not spun up. Now we'll spin up the ALB giving the path to the two microservices that we have created (like and no like) and then deploy our alb-ingress-controller
+7. Still at this point, you'd notice on the console that the ALB has not spun up. Now we'll spin up the ALB giving the path to the two microservices that we have created (like and no like) and then deploy our alb-ingress-controller
   ```
    kubectl apply -f mythical-ingress.yaml 
    kubectl get ingress/mythical-mysfits-eks
   ```
 
-7. Get the DNS name of the alb (kubectl get ingress) or by issuing:
-```
-kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o alb-ingress[a-zA-Z0-9-]+)
-```
-You may see some errors show up about "target not found". That's because we haven't created the backend services yet. Once we create that, you should see the rules and targets created in your ALB.
+8. Get the DNS name of the alb (kubectl get ingress) or by issuing:
+  ```
+  kubectl logs -n kube-system $(kubectl get po -n kube-system | egrep -o alb-ingress[a-zA-Z0-9-]+)
+  ```
+  You may see some errors show up about "target not found". That's because we haven't created the backend services yet. Once we create that, you should see the rules and targets created in your ALB.
 
-(Example: 07f66c03-default-mythicalm-761d-1712518784.us-west-2.elb.amazonaws.com) and modify the index.html file and upload to s3 again
-```
-aws s3 cp ../../workshop-1/web/index.html s3://mythical-mysfits-eks-mythicalbucket-xxx/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
-```
-ALB can take 5-10 mins to be in-service
+  (Example: 07f66c03-default-mythicalm-761d-1712518784.us-west-2.elb.amazonaws.com) and modify the index.html file and upload to s3 again
+  ```
+  aws s3 cp ../../workshop-1/web/index.html s3://mythical-mysfits-eks-mythicalbucket-xxx/ --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers
+  ```
+  ALB can take 5-10 mins to be in-service
 
-8. Take the ALB DNS name and pass it in as environment variable in the *likeservice-app.yaml* file. Again make sure all the other env variables are correct too. Also make sure your nolikeservice-app.yaml file also has the correct ECR ARN and correct DynamoDB name
-```
-- name: mythical-mysfits-like
-          image: PUT_YOUR_LIKE_IMAGE_ECR_ARN
--  env:
-            - name: DDB_TABLE_NAME
-              value: PUT_YOUR_DYNAMODB_TABLENAME
-            - name: AWS_DEFAULT_REGION
-              value: us-west-2
-            - name: MONOLITH_URL
-              value: SAMPLE.us-west-2.elb.amazonaws.com (your ALB name would be different)
+9. Take the ALB DNS name and pass it in as environment variable in the *likeservice-app.yaml* file. Again make sure all the other env variables are correct too. Also make sure your nolikeservice-app.yaml file also has the correct ECR ARN and correct DynamoDB name
+  ```
+  - name: mythical-mysfits-like
+            image: PUT_YOUR_LIKE_IMAGE_ECR_ARN
+  -  env:
+              - name: DDB_TABLE_NAME
+                value: PUT_YOUR_DYNAMODB_TABLENAME
+              - name: AWS_DEFAULT_REGION
+                value: us-west-2
+              - name: MONOLITH_URL
+                value: SAMPLE.us-west-2.elb.amazonaws.com (your ALB name would be different)
 
-```
-**MAKE SURE YOUR DynamoDB table name and your ECR Repos are also pointing to the correct locations in both your likeservice-app.yaml and nolikeservice-app.yaml files**
+  ```
+  **MAKE SURE YOUR DynamoDB table name and your ECR Repos are also pointing to the correct locations in both your likeservice-app.yaml and nolikeservice-app.yaml files**
 
-9. Now deploy both the "like" and "nolike" services. 
+10. Now deploy both the "like" and "nolike" services. 
 ```
 kubectl apply -f likeservice-app.yaml 
 kubectl apply -f nolikeservice-app.yaml
 ```
 
-10. Check your ALB on the console, it will take another 2 minutes or so for these two backend services to show as "healthy" in the target group. 
+11. Check your ALB on the console, it will take another 2 minutes or so for these two backend services to show as "healthy" in the target group. 
 
 ![ALB Rules](images/ALBRules.png)
 
 Targest showing Healthy on ALB
 
 ![HealthyTargets](images/HealthyTargets.png)
-11. Once the state of the pods is showing as healthy, open the log files to each of the pods:
+
+12. Once the state of the pods is showing as healthy, open the log files to each of the pods:
 ```
 kubectl get pods
 kubectl logs <pod name 1> (there should be 4 pods)
 ```
-12. Navigate to the S3 URL and press the like button, you may see the POST with a success of 200 show up and with the message "Like processed." I said you "may" because due to the healthcheck, logs are quite verbose. In the next lab, when we configure CloudWatch with fluentd, you would be able to search for the text in the log groups that are generated. 
+13. Navigate to the S3 URL and press the like button, you may see the POST with a success of 200 show up and with the message "Like processed." I said you "may" because due to the healthcheck, logs are quite verbose. In the next lab, when we configure CloudWatch with fluentd, you would be able to search for the text in the log groups that are generated. 
 
-13. If you have time, you can now remove the old like endpoint from the monolith now that it is no longer seeing production use.
+14. If you have time, you can now remove the old like endpoint from the monolith now that it is no longer seeing production use.
 
     Go back to your Cloud9 environment where you built the monolith and like service container images.
 
-    In the monolith folder, open mythicalMysfitsService.py in the Cloud9 editor and find the code that reads:
+    In the monolith folder, open `mythicalMysfitsService.py` in the Cloud9 editor and find the code that reads:
 
     ```
     # increment the number of likes for the provided mysfit.

--- a/amazon-ecs-mythicalmysfits-workshop/workshop-1/README.md
+++ b/amazon-ecs-mythicalmysfits-workshop/workshop-1/README.md
@@ -651,22 +651,23 @@ This is really important because if you leave stuff running in your account, it 
 
 Delete manually created resources throughout the labs:
 
-* EKS service(s)
+1. Delete EKS service(s)
 
-kubectl delete -f Kubernetes/likeservice-app.yaml
-kubectl delete -f Kubernetes/nolikeservice-app.yaml
-kubectl delete -f Kubernetes/mythical-ingress.yaml
-(if you created the dashboard) kubectl delete -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
+    * kubectl delete -f Kubernetes/likeservice-app.yaml
+    * kubectl delete -f Kubernetes/nolikeservice-app.yaml
+    * kubectl delete -f Kubernetes/mythical-ingress.yaml
+    (if you created the dashboard) kubectl delete -f https://raw.githubusercontent.com/kubernetes/dashboard/v1.10.1/src/deploy/recommended/kubernetes-dashboard.yaml
 
 
-* any roles that you created
-* ECR - delete any Docker images pushed to your ECR repository.
-* CloudWatch logs groups
-* ALBs and associated target groups (if they didn't get deleted when you deleted the service)
-* check DRIFT on your CF stack before you delete and resolve. 
-* eksctl delete cluster --name=mysticalmysfits
+2. Delete Docker images pushed to your ECR repository
+3. Delete S3 buckets with Mythical Mysifts assets
+4. Delete ALBs and associated target groups (if they didn't get deleted when you deleted the service)
+5. Delete CloudWatch log groups
+6. Delete Kubernetes cluster
+    * eksctl delete cluster --name=mysticalmysfits
 
-The nodegroup will have to complete the deletion process before the EKS cluster can be deleted. The total process will take approximately 15 minutes, and can be monitored via the CloudFormation Console
+    The nodegroup will have to complete the deletion process before the EKS cluster can be deleted. The total process will take approximately 15 minutes, and can be monitored via the CloudFormation Console
 
-Finally, [delete the CloudFormation stack](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-delete-stack.html) launched at the beginning of the workshop to clean up the rest.  If the stack deletion process encountered errors, look at the Events tab in the CloudFormation dashboard, and you'll see what steps failed.  It might just be a case where you need to clean up a manually created asset that is tied to a resource goverened by CloudFormation. You can also use the "Drift" detection feature in Cloudformation to figure out what has drifted from the configuration once you started. 
+7. [Delete the CloudFormation stack](http://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/cfn-console-delete-stack.html) launched at the beginning of the workshop to clean up the rest.  If the stack deletion process encountered errors, look at the Events tab in the CloudFormation dashboard, and you'll see what steps failed.  It might just be a case where you need to clean up a manually created asset that is tied to a resource goverened by CloudFormation. You can also use the "Drift" detection feature in Cloudformation to figure out what has drifted from the configuration once you started. 
 
+8. Finally, delete any IAM roles that were created during the lab.

--- a/amazon-ecs-mythicalmysfits-workshop/workshop-1/cfn-output.json
+++ b/amazon-ecs-mythicalmysfits-workshop/workshop-1/cfn-output.json
@@ -1,5 +1,5 @@
 {
   "Cloud9Env": "https://us-west-2.console.aws.amazon.com/cloud9/ide/25127cdec11141d1b7c8c23801566556?region=us-west-2",
-  "DynamoTable": "Table-mythical-mysfits-core",
-  "SiteBucket": "mythical-mysfits-core-mythicalbucket-6b9pvvt40bqj"
+  "DynamoTable": "Table-mythical-mysfits-eks",
+  "SiteBucket": "mythical-mysfits-eks-mythicalbucket-6b9pvvt40bqj"
 }


### PR DESCRIPTION
File names changed from `mythical-mysfits-core` to `mythical-mysfits-eks` where applicable.  Clarified the steps at point 4 of lab 3, so that users know which section of Lab 2 to repeat for the nolike-app and like-app.  Clarified the order in which services need to be spun down in order for the CloudFormation stack deletion not to fail (I was locked out when doing the lab, because I had already deleted the IAM role that gave me permission to work with the CloudFormation stack)